### PR TITLE
Addresses some comments on NOAA-OWP/ngen #405

### DIFF
--- a/include/core/mediator/UnitsHelper.hpp
+++ b/include/core/mediator/UnitsHelper.hpp
@@ -11,7 +11,7 @@ class UnitsHelper {
 
     static double get_converted_value(const std::string &in_units, const double &value, const std::string &out_units);
 
-    static double* get_converted_values(const std::string &in_units, double* values, const std::string &out_units, const size_t & count);
+    static double* convert_values(const std::string &in_units, double* values, const std::string &out_units, double* out_values, const size_t & count);
 
     private:
     static cv_converter* get_converter(const std::string &in_units, const std::string& out_units, ut_unit*& to, ut_unit*& from);

--- a/include/realizations/catchment/Bmi_Module_Formulation.hpp
+++ b/include/realizations/catchment/Bmi_Module_Formulation.hpp
@@ -421,7 +421,7 @@ namespace realization {
                 // Convert units
                 std::string native_units = get_bmi_model()->GetVarUnits(bmi_var_name);
                 try {
-                    UnitsHelper::get_converted_values(native_units, values.data(), output_units, values.size());
+                    UnitsHelper::convert_values(native_units, values.data(), output_units, values.data(), values.size());
                     return values;
                 }
                 catch (const std::runtime_error& e){

--- a/include/utilities/bmi_utilities.hpp
+++ b/include/utilities/bmi_utilities.hpp
@@ -48,6 +48,9 @@ namespace models {
             
             //C++ form of malloc
             void* data = ::operator new(total_mem);
+            // Use smart pointer to ensure cleanup on throw/out of scope...
+            // This works, and is relatively cheap since the lambda is stateless, only one instance should be created.
+            auto sptr = std::shared_ptr<void>(data, [](void *p) { ::operator delete(p); });
             //Delegate to specific adapter's GetValue()
             //Note, may be able to optimize this furthur using GetValuePtr
             //which would avoid copying in the BMI model and copying again here
@@ -100,8 +103,6 @@ namespace models {
                 throw std::runtime_error("Unable to get value of variable " + name +
                                 " as " + boost::typeindex::type_id<T>().pretty_name() + ": no logic for converting variable type " + type);
             }
-            //clean up the temporary data
-            ::operator delete(data); 
             return result;
         }
     }

--- a/src/core/mediator/UnitsHelper.cpp
+++ b/src/core/mediator/UnitsHelper.cpp
@@ -1,4 +1,5 @@
 #include "UnitsHelper.hpp"
+#include <cstring>
 
 ut_system* UnitsHelper::unit_system;
 std::once_flag UnitsHelper::unit_system_inited;
@@ -45,19 +46,25 @@ double UnitsHelper::get_converted_value(const std::string &in_units, const doubl
     return r;
 }
 
-double* UnitsHelper::get_converted_values(const std::string &in_units, double* values, const std::string &out_units, const size_t& count)
+double* UnitsHelper::convert_values(const std::string &in_units, double* in_values, const std::string &out_units, double* out_values, const size_t& count)
 {
     if(in_units == out_units){
-        return values; // Early-out optimization
+        // Early-out optimization
+        if(in_values == out_values){
+            return in_values;
+        } else {
+            memcpy(out_values, in_values, sizeof(double)*count);
+            return out_values;
+        }
     }
     std::call_once(unit_system_inited, init_unit_system);
     ut_unit* to = NULL;
     ut_unit* from = NULL;
     cv_converter* conv = get_converter(in_units, out_units, to, from);
     
-    cv_convert_doubles(conv, values, count, values);
+    cv_convert_doubles(conv, in_values, count, out_values);
     ut_free(from);
     ut_free(to);
     cv_free(conv);
-    return values;
+    return out_values;
 }

--- a/test/core/mediator/UnitsHelper_Tests.cpp
+++ b/test/core/mediator/UnitsHelper_Tests.cpp
@@ -28,7 +28,36 @@ TEST_F(UnitsHelper_Test, TestConvertArray){
     std::vector<double> data = {1,2,3,4};
     std::vector<double> expected = {1000, 2000, 3000, 4000};
     //Call the converter, updates data in place
-    UnitsHelper::get_converted_values("m", data.data(), "mm", data.size());
+    UnitsHelper::convert_values("m", data.data(), "mm", data.data(), data.size());
     ASSERT_EQ( expected,  data);
 
+}
+
+// For coverage completeness...
+TEST_F(UnitsHelper_Test, TestConvertArrayNoOp){
+    std::vector<double> data = {1,2,3,4};
+    std::vector<double> expected = {1, 2, 3, 4};
+    //Call the converter, updates data in place
+    UnitsHelper::convert_values("m", data.data(), "m", data.data(), data.size());
+    ASSERT_EQ( expected,  data);
+}
+
+TEST_F(UnitsHelper_Test, TestConvertArrayDontModifyInput){
+    std::vector<double> data = {1,2,3,4};
+    std::vector<double> data2 = {2,4,6,8};
+    std::vector<double> expected = {1000, 2000, 3000, 4000};
+    //Call the converter, updates data in place
+    UnitsHelper::convert_values("m", data.data(), "mm", data2.data(), data.size());
+    ASSERT_EQ( expected,  data2);
+    ASSERT_EQ( data.at(2), 3);
+}
+
+TEST_F(UnitsHelper_Test, TestConvertArrayDontModifyInputNoOp){
+    std::vector<double> data = {1,2,3,4};
+    std::vector<double> data2 = {2,4,6,8};
+    std::vector<double> expected = {1, 2, 3, 4};
+    //Call the converter, updates data in place
+    UnitsHelper::convert_values("m", data.data(), "m", data2.data(), data.size());
+    ASSERT_EQ( expected,  data2);
+    ASSERT_EQ( data.at(2), 3);
 }


### PR DESCRIPTION
Addresses comments on https://github.com/NOAA-OWP/ngen/pull/405

## Additions

- Attaches heap memory allocated in `models::Bmi::GetValue` to a smart pointer to avoid possible leaks

## Removals

-

## Changes

- Changes `get_converted_values(in_units, values, out_units, count)` to `convert_values(in_units, in_values, out_units, out_values, count)`, where `in_values` and `out_values` may be the same. This makes mutation of the input possible but explicit, similar to  `cv_convert_values`.

## Testing

1. Added tests for additional optimization paths in `convert_values`

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist (automated report can be put here)

1.

### Target Environment support

- [X] Linux
